### PR TITLE
Region Equality and Rotation improvements

### DIFF
--- a/GoRogue.UnitTests/MapGeneration/RegionTests.cs
+++ b/GoRogue.UnitTests/MapGeneration/RegionTests.cs
@@ -164,12 +164,12 @@ namespace GoRogue.UnitTests.MapGeneration
             ne = new Point(8, 4);
             Region hostSubArea = new Region("host sub area", northWest: nw, northEast: ne, southEast: se, southWest: sw);
 
-            mainArea.AddRegion(hostSubArea);
-            mainArea.AddRegion(imposingSubArea);
+            mainArea.AddSubRegion(hostSubArea);
+            mainArea.AddSubRegion(imposingSubArea);
 
             mainArea.DistinguishSubRegions();
-            hostSubArea = mainArea.GetRegion("imposing sub area");
-            imposingSubArea = mainArea.GetRegion("host sub area");
+            hostSubArea = mainArea.GetSubRegion("imposing sub area");
+            imposingSubArea = mainArea.GetSubRegion("host sub area");
 
             foreach (Point c in imposingSubArea.InnerPoints.Positions)
             {
@@ -323,14 +323,14 @@ namespace GoRogue.UnitTests.MapGeneration
         {
             Region house = new Region("house", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw);
 
-            house.AddRegion(new Region("parlor", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
-            house.AddRegion(new Region("ballroom", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
-            house.AddRegion(new Region("kitchenette", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
-            Assert.False(house.HasRegion("house"));
-            Assert.False(house.HasRegion("studio"));
-            Assert.True(house.HasRegion("ballroom"));
-            Assert.True(house.HasRegion("kitchenette"));
-            Assert.True(house.HasRegion("parlor"));
+            house.AddSubRegion(new Region("parlor", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            house.AddSubRegion(new Region("ballroom", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            house.AddSubRegion(new Region("kitchenette", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            Assert.False(house.HasSubRegion("house"));
+            Assert.False(house.HasSubRegion("studio"));
+            Assert.True(house.HasSubRegion("ballroom"));
+            Assert.True(house.HasSubRegion("kitchenette"));
+            Assert.True(house.HasSubRegion("parlor"));
         }
 
         [Fact]
@@ -343,19 +343,19 @@ namespace GoRogue.UnitTests.MapGeneration
         public void SubRegionsTest()
         {
             Region house = new Region("house", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw);
-            house.AddRegion(new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddSubRegion(new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(1, house.SubRegions.Count);
-            house.AddRegion(new Region("hall", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddSubRegion(new Region("hall", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(2, house.SubRegions.Count);
-            house.AddRegion(new Region("shitter", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddSubRegion(new Region("shitter", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(3, house.SubRegions.Count);
 
             Region expected = new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2);
 
-            Assert.True(expected.Matches(house.GetRegion("parlor")));
+            Assert.True(expected.Matches(house.GetSubRegion("parlor")));
 
 
-            house.RemoveRegion("hall");
+            house.RemoveSubRegion("hall");
             Assert.Equal(2, house.SubRegions.Count);
         }
         public void Dispose()

--- a/GoRogue.UnitTests/MapGeneration/RegionTests.cs
+++ b/GoRogue.UnitTests/MapGeneration/RegionTests.cs
@@ -164,8 +164,8 @@ namespace GoRogue.UnitTests.MapGeneration
             ne = new Point(8, 4);
             Region hostSubArea = new Region("host sub area", northWest: nw, northEast: ne, southEast: se, southWest: sw);
 
-            mainArea.Add(hostSubArea);
-            mainArea.Add(imposingSubArea);
+            mainArea.AddRegion(hostSubArea);
+            mainArea.AddRegion(imposingSubArea);
 
             mainArea.DistinguishSubRegions();
             hostSubArea = mainArea.GetRegion("imposing sub area");
@@ -267,7 +267,7 @@ namespace GoRogue.UnitTests.MapGeneration
             Assert.True(prior.SouthEastCorner.X < post.SouthEastCorner.X);
             Assert.True(prior.SouthEastCorner.Y < post.SouthEastCorner.Y);
 
-            Assert.Equal(copyOfPrior, prior);
+            Assert.True(copyOfPrior.Matches(prior));
         }
 
         [Fact]
@@ -281,7 +281,7 @@ namespace GoRogue.UnitTests.MapGeneration
             Point se = room.SouthEastCorner;
             Point ne = room.NorthEastCorner;
 
-            Assert.Equal(nw, new Point(1, 1));
+            Assert.Equal(new Point(1, 1), nw);
 
             Assert.True(nw.X > sw.X);
             Assert.True(sw.Y > nw.Y);
@@ -323,9 +323,9 @@ namespace GoRogue.UnitTests.MapGeneration
         {
             Region house = new Region("house", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw);
 
-            house.Add(new Region("parlor", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
-            house.Add(new Region("ballroom", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
-            house.Add(new Region("kitchenette", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            house.AddRegion(new Region("parlor", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            house.AddRegion(new Region("ballroom", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
+            house.AddRegion(new Region("kitchenette", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw));
             Assert.False(house.HasRegion("house"));
             Assert.False(house.HasRegion("studio"));
             Assert.True(house.HasRegion("ballroom"));
@@ -343,19 +343,19 @@ namespace GoRogue.UnitTests.MapGeneration
         public void SubRegionsTest()
         {
             Region house = new Region("house", northWest: _nw, northEast: _ne, southEast: _se, southWest: _sw);
-            house.Add(new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddRegion(new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(1, house.SubRegions.Count);
-            house.Add(new Region("hall", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddRegion(new Region("hall", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(2, house.SubRegions.Count);
-            house.Add(new Region("shitter", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
+            house.AddRegion(new Region("shitter", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2));
             Assert.Equal(3, house.SubRegions.Count);
 
             Region expected = new Region("parlor", northWest: _nw + 1, northEast: _ne + 3, southEast: _se + 3, southWest: _sw + 2);
 
-            Assert.Equal(expected, house.GetRegion("parlor"));
+            Assert.True(expected.Matches(house.GetRegion("parlor")));
 
 
-            house.Remove("hall");
+            house.RemoveRegion("hall");
             Assert.Equal(2, house.SubRegions.Count);
         }
         public void Dispose()

--- a/GoRogue/GoRogue.csproj
+++ b/GoRogue/GoRogue.csproj
@@ -84,7 +84,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha5" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha6-debug" />
     <PackageReference Include="Troschuetz.Random" Version="5.0.1" />
   </ItemGroup>
 

--- a/GoRogue/GoRogue.csproj
+++ b/GoRogue/GoRogue.csproj
@@ -84,7 +84,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha6-debug" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha7" />
     <PackageReference Include="Troschuetz.Random" Version="5.0.1" />
   </ItemGroup>
 

--- a/GoRogue/MapGeneration/Region.Static.cs
+++ b/GoRogue/MapGeneration/Region.Static.cs
@@ -80,52 +80,5 @@ namespace GoRogue.MapGeneration
 
             return points;
         }
-
-
-        /// <summary>
-        /// Rotates a single point around the origin (0, 0).
-        /// </summary>
-        /// <param name="point">The Point to rotate</param>
-        /// <param name="radians">The amount of Radians to rotate this point</param>
-        /// <returns>The equivalent point after a rotation</returns>
-        /// <remarks>
-        /// This is intended only as a helper class for rotation, and not for general use.
-        /// Intended usage is like so:
-        /// `Point sw = RotatePoint(SouthWestCorner - origin, radians) + origin;`
-        /// </remarks>
-        private static Point RotatePoint(Point point, in double radians)
-        {
-            int x = (int)Math.Round(point.X * Math.Cos(radians) - point.Y * Math.Sin(radians));
-            int y = (int)Math.Round(point.X * Math.Sin(radians) + point.Y * Math.Cos(radians));
-            return new Point(x, y);
-        }
-
-        /// <summary>
-        /// True if the regions have the same corners/centers; false otherwise.
-        /// </summary>
-        /// <param name="left"/>
-        /// <param name="right"/>
-        /// <returns/>
-        public static bool operator ==(Region? left, Region? right)
-        {
-            if (left is null || right is null)
-                return ReferenceEquals(left, right); // They're both null if this returns true;
-
-            bool equals = left.Name == right.Name;
-            if (left.NorthWestCorner != right.NorthWestCorner) equals = false;
-            if (left.SouthWestCorner != right.SouthWestCorner) equals = false;
-            if (left.NorthEastCorner != right.NorthEastCorner) equals = false;
-            if (left.SouthEastCorner != right.SouthEastCorner) equals = false;
-            if (left.Center != right.Center) equals = false;
-            return equals;
-        }
-
-        /// <summary>
-        /// False if the regions have the same corners and centers; false otherwise.
-        /// </summary>
-        /// <param name="left"/>
-        /// <param name="right"/>
-        /// <returns/>
-        public static bool operator !=(Region? left, Region? right) => !(left == right);
     }
 }

--- a/GoRogue/MapGeneration/Region.cs
+++ b/GoRogue/MapGeneration/Region.cs
@@ -48,8 +48,9 @@ namespace GoRogue.MapGeneration
         /// </summary>
         /// <param name="other">the region against which to compare</param>
         /// <returns></returns>
-        public bool Matches(Region other)
+        public bool Matches(Region? other)
         {
+            if (other is null) return false;
             if (Name != other.Name) return false;
             if (NorthWestCorner != other.NorthWestCorner) return false;
             if (SouthWestCorner != other.SouthWestCorner) return false;
@@ -174,7 +175,7 @@ namespace GoRogue.MapGeneration
         /// </summary>
         /// <param name="name">name of the region to analyze</param>
         /// <returns>whether the specified region exists</returns>
-        public bool HasRegion(string name) => SubRegions.Any(r => r.Name == name);
+        public bool HasSubRegion(string name) => SubRegions.Any(r => r.Name == name);
 
         /// <summary>
         /// Removes a common point from the OuterPoints of both regions
@@ -325,7 +326,7 @@ namespace GoRogue.MapGeneration
         /// Adds a sub-region to this region.
         /// </summary>
         /// <param name="region">The region you wish to add as a sub-region</param>
-        public void AddRegion(Region region)
+        public void AddSubRegion(Region region)
         {
             _subRegions.Add(region);
         }
@@ -333,19 +334,19 @@ namespace GoRogue.MapGeneration
         /// Removes a sub-region whose name matches with the string given.
         /// </summary>
         /// <param name="name">Key of sub-region to remove.</param>
-        public void RemoveRegion(string name)
+        public void RemoveSubRegion(string name)
         {
-            if (HasRegion(name))
-                _subRegions.Remove(GetRegion(name));
+            if (HasSubRegion(name))
+                _subRegions.Remove(GetSubRegion(name));
         }
 
         /// <summary>
         /// Get a sub-region by its name.
         /// </summary>
         /// <param name="name">The name of the region to find</param>
-        public Region GetRegion(string name)
+        public Region GetSubRegion(string name)
         {
-            if (HasRegion(name))
+            if (HasSubRegion(name))
                 return SubRegions.First(r => r.Name == name);
             else
                 throw new KeyNotFoundException("No sub-region named " + name + " was found");

--- a/GoRogue/MapGeneration/Region.cs
+++ b/GoRogue/MapGeneration/Region.cs
@@ -12,7 +12,7 @@ namespace GoRogue.MapGeneration
     /// A region of the map with four sides of arbitrary shape and size
     /// </summary>
     [PublicAPI]
-    public partial class Region
+    public partial class Region : IMatchable<Region>
     {
         #region Generation
 
@@ -42,36 +42,30 @@ namespace GoRogue.MapGeneration
         #endregion
 
         #region Overrides
+
+        /// <summary>
+        /// Returns whether or not this region is completely overlapping with the other region
+        /// </summary>
+        /// <param name="other">the region against which to compare</param>
+        /// <returns></returns>
+        public bool Matches(Region other)
+        {
+            if (Name != other.Name) return false;
+            if (NorthWestCorner != other.NorthWestCorner) return false;
+            if (SouthWestCorner != other.SouthWestCorner) return false;
+            if (NorthEastCorner != other.NorthEastCorner) return false;
+            if (SouthEastCorner != other.SouthEastCorner) return false;
+            if (Center != other.Center) return false;
+
+            return true;
+        }
+
         /// <summary>
         /// Returns a string detailing the region's corner locations.
         /// </summary>
         /// <returns/>
         public override string ToString()
-        {
-            return Name + ": NW" + NorthWestCorner +"=> NE" + NorthEastCorner + "=> SE" + SouthEastCorner + "=> SW" + SouthWestCorner;
-        }
-
-        /// <summary>
-        /// True if the given object is a region that has the same corner/centers; false otherwise.
-        /// </summary>
-        /// <param name="obj"/>
-        /// <returns/>
-        public override bool Equals(object? obj) => obj is Region region && this == region;
-
-        /// <summary>
-        /// To facilitate in equality operations
-        /// </summary>
-        /// <returns>The Hash Code of the Region</returns>
-        /// <remarks>
-        /// Due to the nature of Connections being personal to the map generation algorithm,
-        /// connections are not considered when evaluating a region's Hash Code.
-        /// </remarks>
-        public override int GetHashCode()
-        {
-            return SouthEastCorner.GetHashCode() + NorthEastCorner.GetHashCode() + SouthWestCorner.GetHashCode() +
-                       NorthWestCorner.GetHashCode() + Center.GetHashCode();
-        }
-
+            => $"{Name}: NW{NorthWestCorner.ToString()}=> NE{NorthEastCorner.ToString()}=> SE{SouthEastCorner.ToString()}=> SW{SouthWestCorner.ToString()}";
         #endregion
 
         #region Management
@@ -295,29 +289,28 @@ namespace GoRogue.MapGeneration
         public virtual Region Rotate(double degrees, Point origin)
         {
             degrees = MathHelpers.WrapAround(degrees, 360);
-            double radians = SadRogue.Primitives.MathHelpers.ToRadian(degrees);
 
             //figure out the new corners post-rotation
             List<Point> corners = new List<Point>();
-            Point southwest = RotatePoint(SouthWestCorner - origin, radians) + origin;
+            Point southwest = SouthWestCorner.Rotate(degrees, origin);
             corners.Add(southwest);
-            Point southeast = RotatePoint(SouthEastCorner - origin, radians) + origin;
+            Point southeast = SouthEastCorner.Rotate(degrees, origin);
             corners.Add(southeast);
-            Point northwest = RotatePoint(NorthWestCorner - origin, radians) + origin;
+            Point northwest = NorthWestCorner.Rotate(degrees, origin);
             corners.Add(northwest);
-            Point northeast = RotatePoint(NorthEastCorner - origin, radians) + origin;
+            Point northeast = NorthEastCorner.Rotate(degrees, origin);
             corners.Add(northeast);
 
             //order the new corner by Y-value
             corners = corners.OrderBy(corner => Direction.YIncreasesUpward ? -corner.Y : corner.Y).ToList();
 
             //split that list in half and then sort by X-value
-            Point[] topTwo = new Point[] { corners[0], corners[1] };
+            Point[] topTwo = { corners[0], corners[1] };
             topTwo = topTwo.OrderBy(c => c.X).ToArray();
             northwest = topTwo[0];
             northeast = topTwo[1];
 
-            Point[] bottomTwo = new Point[] { corners [2], corners [3] };
+            Point[] bottomTwo = { corners [2], corners [3] };
             bottomTwo = bottomTwo.OrderBy(c => c.X).ToArray();
             southwest = bottomTwo[0];
             southeast = bottomTwo[1];
@@ -332,7 +325,7 @@ namespace GoRogue.MapGeneration
         /// Adds a sub-region to this region.
         /// </summary>
         /// <param name="region">The region you wish to add as a sub-region</param>
-        public void Add(Region region)
+        public void AddRegion(Region region)
         {
             _subRegions.Add(region);
         }
@@ -340,7 +333,7 @@ namespace GoRogue.MapGeneration
         /// Removes a sub-region whose name matches with the string given.
         /// </summary>
         /// <param name="name">Key of sub-region to remove.</param>
-        public void Remove(string name)
+        public void RemoveRegion(string name)
         {
             if (HasRegion(name))
                 _subRegions.Remove(GetRegion(name));


### PR DESCRIPTION
removed equality / get hash code, implemented IMatches<Region>, rotate now uses the primitives rotation and deleted the method from region.

If accepted, this will close issues numbers #183 and #184 