### PR TITLE
Added Intelligent PolygonArea comparison

### DIFF
--- a/GoRogue.UnitTests/MapGeneration/PolygonAreaTests.cs
+++ b/GoRogue.UnitTests/MapGeneration/PolygonAreaTests.cs
@@ -366,5 +366,38 @@ namespace GoRogue.UnitTests.MapGeneration
         }
         #endregion
 
+        #region Comparison Tests
+
+        [Fact]
+        public void MatchesTest()
+        {
+            // Two identical polygons (separate instances)
+            var poly1 = new PolygonArea((0, 1), (5, 0), (1, 2));
+            var poly2 = new PolygonArea((0, 1), (5, 0), (1, 2));
+
+            // Equivalent polygon just with the corners defined using a different starting point
+            var poly3 = new PolygonArea((5, 0), (1, 2), (0, 1));
+
+            // Not equivalent polygon
+            var poly4 = new PolygonArea((5, 0), (0, 1), (1, 2));
+
+            Assert.True(poly1.Matches(poly2));
+            Assert.True(poly1.Matches(poly3));
+
+            Assert.False(poly1.Matches(poly4));
+
+            // Repeat the tests with the objects casted to an interface to ensure the comparison propagates
+            var area1 = poly1 as IReadOnlyArea;
+            var area2 = poly2 as IReadOnlyArea;
+            var area3 = poly3 as IReadOnlyArea;
+            var area4 = poly4 as IReadOnlyArea;
+
+            Assert.True(area1.Matches(area2));
+            Assert.True(area1.Matches(area3));
+
+            Assert.False(area1.Matches(area4));
+        }
+        #endregion
+
     }
 }

--- a/GoRogue/GoRogue.csproj
+++ b/GoRogue/GoRogue.csproj
@@ -11,12 +11,12 @@
     Configure versioning information, making sure to append "debug" to Debug version to allow publishing
     to NuGet seperately from Release version.
     -->
-    <Version>3.0.0-alpha05</Version>
+    <Version>3.0.0-alpha06</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 
 	<!-- More nuget package settings-->
     <PackageId>GoRogue</PackageId>
-	<PackageReleaseNotes>BREAKING CHANGES from v2!  See upgrade guide at http://www.roguelib.com/articles/2-to-3-upgrade-guide.html.  Changelog at https://github.com/Chris3606/GoRogue/blob/develop-3.0/changelog.md#300-alpha05---2021-09-30.</PackageReleaseNotes>
+	<PackageReleaseNotes>BREAKING CHANGES from v2!  See upgrade guide at http://www.roguelib.com/articles/2-to-3-upgrade-guide.html.  Changelog at https://github.com/Chris3606/GoRogue/blob/develop-3.0/changelog.md#300-alpha06---2021-10-02.</PackageReleaseNotes>
 	<PackageProjectUrl>http://www.roguelib.com</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/Chris3606/GoRogue/tree/develop-3.0</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>

--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ None.
     - Such functions and constructors are now only available by accessing `Area` property
 
 ### Fixed
-- `Parallelogram` static creation method for `PolygonArea` now functions correctly for differing values of width/height
+- `Parallelogram` static creation method for `PolygonArea` now functions correctly for differing values of width/height (ensures correct 45 degree angles)
 
 ## [3.0.0-alpha05] - 2021-09-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ None.
 - Added a constructor to `Region` that takes a `PolygonArea` as a parameter and avoided copies.
 - Added an event that will automatically fire when the `Area` property of a `Region` is changed.
 
+### Changed
+- Comparison of `PolygonArea` now compares exclusively based off of defined corner equivalency.
+
 ### Removed
 - All functions and constructors in `Region` that forwarded to corresponsding functions in `PolygonArea`.
     - Such functions and constructors are now only available by accessing `Area` property

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None.
 
+## [3.0.0-alpha06] - 2021-10-02
+
+### Added
+- Added a constructor to `Region` that takes a `PolygonArea` as a parameter and avoided copies.
+- Added an event that will automatically fire when the `Area` property of a `Region` is changed.
+
+### Removed
+- All functions and constructors in `Region` that forwarded to corresponsding functions in `PolygonArea`.
+    - Such functions and constructors are now only available by accessing `Area` property
+
+### Fixed
+- `Parallelogram` static creation method for `PolygonArea` now functions correctly for differing values of width/height
+
 ## [3.0.0-alpha05] - 2021-09-30
 
 ### Added


### PR DESCRIPTION
- Bumped version numbers for 3.0.0-alpha6 release.
- Added a more "correct" comparison for `PolygonArea` instances, and accompanying unit tests.
- Updated changelog