### PR TITLE
Bugfixes and MessageBus Enhancements

### DIFF
--- a/GoRogue.PerformanceTests/Messaging/ExpressionMessageBus.cs
+++ b/GoRogue.PerformanceTests/Messaging/ExpressionMessageBus.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GoRogue.Messaging;
+
+namespace GoRogue.PerformanceTests.Messaging
+{
+    public class ExpressionMessageBus
+    {
+        private readonly Dictionary<Type, List<(object subscriber, Action<object> handler)>> _subscriberRefs;
+        private readonly Dictionary<Type, Type[]> _typeTreeCache;
+
+        public ExpressionMessageBus()
+        {
+            _subscriberRefs = new Dictionary<Type, List<(object subscriber, Action<object> handler)>>();
+            _typeTreeCache = new Dictionary<Type, Type[]>();
+            SubscriberCount = 0;
+        }
+
+        public int SubscriberCount { get; private set; }
+
+        public ISubscriber<TMessage> RegisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (!_subscriberRefs.ContainsKey(messageType))
+                _subscriberRefs[messageType] = new List<(object subscriber, Action<object> handler)>();
+            else if (_subscriberRefs[messageType].Any(i => ReferenceEquals(i.subscriber, subscriber)))
+                throw new ArgumentException("Subscriber added to message bus twice.", nameof(subscriber));
+
+            _subscriberRefs[messageType].Add((subscriber, msg => subscriber.Handle((TMessage)msg)));
+            SubscriberCount++;
+
+            return subscriber;
+        }
+
+        public void UnregisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (_subscriberRefs.TryGetValue(messageType, out List<(object subscriber, Action<object> handler)>? handlerRefs))
+            {
+                var item = handlerRefs.FindIndex(i => ReferenceEquals(i.subscriber, subscriber));
+
+                if (item == -1)
+                    throw new ArgumentException(
+                        $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+
+                handlerRefs.RemoveAt(item);
+                if (handlerRefs.Count == 0)
+                    _subscriberRefs.Remove(messageType);
+
+                SubscriberCount--;
+            }
+            else
+                throw new ArgumentException(
+                    $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+        }
+
+        public void Send<TMessage>(TMessage message) where TMessage : notnull
+        {
+            var runtimeMessageType = message.GetType();
+            if (!_typeTreeCache.TryGetValue(runtimeMessageType, out Type[]? types))
+                types = _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
+
+            foreach (var type in types)
+                if (_subscriberRefs.TryGetValue(type, out List<(object subscriber, Action<object> handler)>? handlerRefs))
+                    foreach (var handlerRef in handlerRefs)
+                        handlerRef.handler(message);
+        }
+    }
+}

--- a/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
+++ b/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
@@ -29,7 +29,8 @@ namespace GoRogue.PerformanceTests.Messaging
         [Params("message")]
         public string Message = null!;
 
-        private MessageBus _originalBus = null!;
+        private MessageBus _currentGoRogueBus = null!;
+        private OriginalMessageBus _originalBus = null!;
         private NoForEachMessageBus _noForeachBus = null!;
         private ExpressionMessageBus _expressionBus = null!;
         private OptimizedAndCacheSubsMessageBus _cachedSubsBus = null!;
@@ -39,7 +40,8 @@ namespace GoRogue.PerformanceTests.Messaging
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _originalBus = new MessageBus();
+            _currentGoRogueBus = new MessageBus();
+            _originalBus = new OriginalMessageBus();
             _noForeachBus = new NoForEachMessageBus();
             _expressionBus = new ExpressionMessageBus();
             _cachedSubsBus = new OptimizedAndCacheSubsMessageBus();
@@ -48,6 +50,7 @@ namespace GoRogue.PerformanceTests.Messaging
 
             for (int i = 0; i < Subscribers; i++)
             {
+                _currentGoRogueBus.RegisterSubscriber(new BenchmarkSubscriber());
                 _originalBus.RegisterSubscriber(new BenchmarkSubscriber());
                 _noForeachBus.RegisterSubscriber(new BenchmarkSubscriber());
                 _expressionBus.RegisterSubscriber(new BenchmarkSubscriber());
@@ -58,12 +61,19 @@ namespace GoRogue.PerformanceTests.Messaging
         }
 
         [Benchmark]
+        public void CurrentGoRogue()
+        {
+            for (int i = 0; i < Messages; i++)
+                _currentGoRogueBus.Send(Message);
+        }
+
+        [Benchmark]
         public void Original()
         {
             for (int i = 0; i < Messages; i++)
                 _originalBus.Send(Message);
         }
-
+        
         [Benchmark]
         public void NoForEach()
         {

--- a/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
+++ b/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
@@ -1,0 +1,74 @@
+﻿using BenchmarkDotNet.Attributes;
+using GoRogue.Messaging;
+using JetBrains.Annotations;
+
+namespace GoRogue.PerformanceTests.Messaging
+{
+    public class BenchmarkSubscriber : ISubscriber<string>
+    {
+        [UsedImplicitly]
+        private string _mostRecentMessage = "";
+
+        public void Handle(string message)
+        {
+            _mostRecentMessage = message;
+        }
+    }
+
+    public class MessageBusSend
+    {
+        [UsedImplicitly]
+        [Params(10, 100, 1000, 10000)]
+        public int Messages;
+
+        [UsedImplicitly]
+        [Params(1000)]
+        public int Subscribers;
+
+        [UsedImplicitly]
+        [Params("message")]
+        public string Message = null!;
+
+        private MessageBus _originalBus = null!;
+        private NoForEachMessageBus _noForeachBus = null!;
+        private ExpressionMessageBus _expressionBus = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _originalBus = new MessageBus();
+            _noForeachBus = new NoForEachMessageBus();
+            _expressionBus = new ExpressionMessageBus();
+
+            for (int i = 0; i < Subscribers; i++)
+            {
+                _originalBus.RegisterSubscriber(new BenchmarkSubscriber());
+                _noForeachBus.RegisterSubscriber(new BenchmarkSubscriber());
+                _expressionBus.RegisterSubscriber(new BenchmarkSubscriber());
+            }
+
+        }
+
+        [Benchmark]
+        public void Original()
+        {
+            for (int i = 0; i < Messages; i++)
+                _originalBus.Send(Message);
+        }
+
+        [Benchmark]
+        public void NoForEach()
+        {
+            for (int i = 0; i < Messages; i++)
+                _noForeachBus.Send(Message);
+        }
+
+        [Benchmark]
+        public void Expression()
+        {
+            for (int i = 0; i < Messages; i++)
+                _expressionBus.Send(Message);
+        }
+
+    }
+}

--- a/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
+++ b/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
@@ -34,6 +34,7 @@ namespace GoRogue.PerformanceTests.Messaging
         private ExpressionMessageBus _expressionBus = null!;
         private OptimizedAndCacheSubsMessageBus _cachedSubsBus = null!;
         private OptimizedAndToArrayMessageBus _toArrayBus = null!;
+        private OptimizedAndToArrayAllMessageBus _toArrayAllBus = null!;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -43,14 +44,17 @@ namespace GoRogue.PerformanceTests.Messaging
             _expressionBus = new ExpressionMessageBus();
             _cachedSubsBus = new OptimizedAndCacheSubsMessageBus();
             _toArrayBus = new OptimizedAndToArrayMessageBus();
+            _toArrayAllBus = new OptimizedAndToArrayAllMessageBus();
 
             for (int i = 0; i < Subscribers; i++)
             {
                 _originalBus.RegisterSubscriber(new BenchmarkSubscriber());
                 _noForeachBus.RegisterSubscriber(new BenchmarkSubscriber());
                 _expressionBus.RegisterSubscriber(new BenchmarkSubscriber());
+                _cachedSubsBus.RegisterSubscriber(new BenchmarkSubscriber());
+                _toArrayBus.RegisterSubscriber(new BenchmarkSubscriber());
+                _toArrayAllBus.RegisterSubscriber(new BenchmarkSubscriber());
             }
-
         }
 
         [Benchmark]
@@ -86,6 +90,13 @@ namespace GoRogue.PerformanceTests.Messaging
         {
             for (int i = 0; i < Messages; i++)
                 _toArrayBus.Send(Message);
+        }
+
+        [Benchmark]
+        public void OptimizeToArrayAll()
+        {
+            for (int i = 0; i < Messages; i++)
+                _toArrayAllBus.Send(Message);
         }
 
     }

--- a/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
+++ b/GoRogue.PerformanceTests/Messaging/MessageBusSend.cs
@@ -32,6 +32,8 @@ namespace GoRogue.PerformanceTests.Messaging
         private MessageBus _originalBus = null!;
         private NoForEachMessageBus _noForeachBus = null!;
         private ExpressionMessageBus _expressionBus = null!;
+        private OptimizedAndCacheSubsMessageBus _cachedSubsBus = null!;
+        private OptimizedAndToArrayMessageBus _toArrayBus = null!;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -39,6 +41,8 @@ namespace GoRogue.PerformanceTests.Messaging
             _originalBus = new MessageBus();
             _noForeachBus = new NoForEachMessageBus();
             _expressionBus = new ExpressionMessageBus();
+            _cachedSubsBus = new OptimizedAndCacheSubsMessageBus();
+            _toArrayBus = new OptimizedAndToArrayMessageBus();
 
             for (int i = 0; i < Subscribers; i++)
             {
@@ -68,6 +72,20 @@ namespace GoRogue.PerformanceTests.Messaging
         {
             for (int i = 0; i < Messages; i++)
                 _expressionBus.Send(Message);
+        }
+
+        [Benchmark]
+        public void OptimizeCachedSubs()
+        {
+            for (int i = 0; i < Messages; i++)
+                _cachedSubsBus.Send(Message);
+        }
+
+        [Benchmark]
+        public void OptimizeToArray()
+        {
+            for (int i = 0; i < Messages; i++)
+                _toArrayBus.Send(Message);
         }
 
     }

--- a/GoRogue.PerformanceTests/Messaging/NoForEachMessageBus.cs
+++ b/GoRogue.PerformanceTests/Messaging/NoForEachMessageBus.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GoRogue.Messaging;
+
+namespace GoRogue.PerformanceTests.Messaging
+{
+    public class NoForEachMessageBus
+    {
+        private readonly Dictionary<Type, List<ISubscriberRef>> _subscriberRefs;
+        private readonly Dictionary<Type, Type[]> _typeTreeCache;
+
+        public NoForEachMessageBus()
+        {
+            _subscriberRefs = new Dictionary<Type, List<ISubscriberRef>>();
+            _typeTreeCache = new Dictionary<Type, Type[]>();
+            SubscriberCount = 0;
+        }
+
+        public int SubscriberCount { get; private set; }
+
+        public ISubscriber<TMessage> RegisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (!_subscriberRefs.ContainsKey(messageType))
+                _subscriberRefs[messageType] = new List<ISubscriberRef>();
+            else if (_subscriberRefs[messageType].Any(i => ReferenceEquals(i.Subscriber, subscriber)))
+                throw new ArgumentException("Subscriber added to message bus twice.", nameof(subscriber));
+
+            _subscriberRefs[messageType].Add(new SubscriberRef<TMessage>(subscriber));
+            SubscriberCount++;
+
+            return subscriber;
+        }
+
+        public void UnregisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (_subscriberRefs.TryGetValue(messageType, out List<ISubscriberRef>? handlerRefs))
+            {
+                var item = handlerRefs.FindIndex(i => ReferenceEquals(i.Subscriber, subscriber));
+
+                if (item == -1)
+                    throw new ArgumentException(
+                        $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+
+                handlerRefs.RemoveAt(item);
+                if (handlerRefs.Count == 0)
+                    _subscriberRefs.Remove(messageType);
+
+                SubscriberCount--;
+            }
+            else
+                throw new ArgumentException(
+                    $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+        }
+
+        public void Send<TMessage>(TMessage message) where TMessage : notnull
+        {
+            var runtimeMessageType = message.GetType();
+            if (!_typeTreeCache.TryGetValue(runtimeMessageType, out Type[]? types))
+                types = _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
+
+
+            for (int i = 0; i < types.Length; i++)
+            {
+                var type = types[i];
+                if (_subscriberRefs.TryGetValue(type, out List<ISubscriberRef>? handlerRefs))
+                    foreach (var handlerRef in handlerRefs)
+                        handlerRef.Handler(message);
+            }
+        }
+    }
+}

--- a/GoRogue.PerformanceTests/Messaging/OptimizedAndToArrayMessageBus.cs
+++ b/GoRogue.PerformanceTests/Messaging/OptimizedAndToArrayMessageBus.cs
@@ -5,14 +5,14 @@ using GoRogue.Messaging;
 
 namespace GoRogue.PerformanceTests.Messaging
 {
-    public class NoForEachMessageBus
+    public class OptimizedAndToArrayMessageBus
     {
-        private readonly Dictionary<Type, List<ISubscriberRef>> _subscriberRefs;
+        private readonly Dictionary<Type, List<(object subscriber, Action<object> handler)>> _subscriberRefs;
         private readonly Dictionary<Type, Type[]> _typeTreeCache;
 
-        public NoForEachMessageBus()
+        public OptimizedAndToArrayMessageBus()
         {
-            _subscriberRefs = new Dictionary<Type, List<ISubscriberRef>>();
+            _subscriberRefs = new Dictionary<Type, List<(object subscriber, Action<object> handler)>>();
             _typeTreeCache = new Dictionary<Type, Type[]>();
             SubscriberCount = 0;
         }
@@ -24,11 +24,11 @@ namespace GoRogue.PerformanceTests.Messaging
             var messageType = typeof(TMessage);
 
             if (!_subscriberRefs.ContainsKey(messageType))
-                _subscriberRefs[messageType] = new List<ISubscriberRef>();
-            else if (_subscriberRefs[messageType].Any(i => ReferenceEquals(i.Subscriber, subscriber)))
+                _subscriberRefs[messageType] = new List<(object subscriber, Action<object> handler)>();
+            else if (_subscriberRefs[messageType].Any(i => ReferenceEquals(i.subscriber, subscriber)))
                 throw new ArgumentException("Subscriber added to message bus twice.", nameof(subscriber));
 
-            _subscriberRefs[messageType].Add(new SubscriberRef<TMessage>(subscriber));
+            _subscriberRefs[messageType].Add((subscriber, msg => subscriber.Handle((TMessage)msg)));
             SubscriberCount++;
 
             return subscriber;
@@ -38,9 +38,9 @@ namespace GoRogue.PerformanceTests.Messaging
         {
             var messageType = typeof(TMessage);
 
-            if (_subscriberRefs.TryGetValue(messageType, out List<ISubscriberRef>? handlerRefs))
+            if (_subscriberRefs.TryGetValue(messageType, out List<(object subscriber, Action<object> handler)>? handlerRefs))
             {
-                var item = handlerRefs.FindIndex(i => ReferenceEquals(i.Subscriber, subscriber));
+                var item = handlerRefs.FindIndex(i => ReferenceEquals(i.subscriber, subscriber));
 
                 if (item == -1)
                     throw new ArgumentException(
@@ -63,13 +63,16 @@ namespace GoRogue.PerformanceTests.Messaging
             if (!_typeTreeCache.TryGetValue(runtimeMessageType, out Type[]? types))
                 types = _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
 
-
             for (int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
-                if (_subscriberRefs.TryGetValue(type, out List<ISubscriberRef>? handlerRefs))
-                    for (int j = 0; j < handlerRefs.Count; j++)
-                        handlerRefs[j].Handler(message);
+                if (_subscriberRefs.TryGetValue(type,
+                    out List<(object subscriber, Action<object> handler)>? handlerRefs))
+                {
+                    var handlers = handlerRefs.ToArray();
+                    for (int j = 0; j < handlers.Length; j++)
+                        handlers[j].handler(message);
+                }
             }
         }
     }

--- a/GoRogue.PerformanceTests/Messaging/OriginalMessageBus.cs
+++ b/GoRogue.PerformanceTests/Messaging/OriginalMessageBus.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GoRogue.Messaging;
+
+namespace GoRogue.PerformanceTests.Messaging
+{
+    public class OriginalMessageBus
+    {
+        private readonly Dictionary<Type, List<ISubscriberRef>> _subscriberRefs;
+        private readonly Dictionary<Type, Type[]> _typeTreeCache;
+
+        public OriginalMessageBus()
+        {
+            _subscriberRefs = new Dictionary<Type, List<ISubscriberRef>>();
+            _typeTreeCache = new Dictionary<Type, Type[]>();
+            SubscriberCount = 0;
+        }
+
+
+        public int SubscriberCount { get; private set; }
+
+
+        public ISubscriber<TMessage> RegisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (!_subscriberRefs.ContainsKey(messageType))
+                _subscriberRefs[messageType] = new List<ISubscriberRef>();
+            else if (_subscriberRefs[messageType].Any(i => ReferenceEquals(i.Subscriber, subscriber)))
+                throw new ArgumentException("Subscriber added to message bus twice.", nameof(subscriber));
+
+            _subscriberRefs[messageType].Add(new SubscriberRef<TMessage>(subscriber));
+            SubscriberCount++;
+
+            return subscriber;
+        }
+
+        public void UnregisterSubscriber<TMessage>(ISubscriber<TMessage> subscriber)
+        {
+            var messageType = typeof(TMessage);
+
+            if (_subscriberRefs.TryGetValue(messageType, out List<ISubscriberRef>? handlerRefs))
+            {
+                var item = handlerRefs.FindIndex(i => ReferenceEquals(i.Subscriber, subscriber));
+
+                if (item == -1)
+                    throw new ArgumentException(
+                        $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+
+                handlerRefs.RemoveAt(item);
+                if (handlerRefs.Count == 0)
+                    _subscriberRefs.Remove(messageType);
+
+                SubscriberCount--;
+            }
+            else
+                throw new ArgumentException(
+                    $"Tried to remove a subscriber from a {nameof(MessageBus)} that was never added.");
+        }
+
+        public void Send<TMessage>(TMessage message) where TMessage : notnull
+        {
+            var runtimeMessageType = message.GetType();
+            if (!_typeTreeCache.TryGetValue(runtimeMessageType, out Type[]? types))
+                types = _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
+
+            foreach (var type in types)
+                if (_subscriberRefs.TryGetValue(type, out List<ISubscriberRef>? handlerRefs))
+                    foreach (var handlerRef in handlerRefs)
+                        handlerRef.Handler(message);
+        }
+    }
+}

--- a/GoRogue.PerformanceTests/Messaging/SubscriberRef.cs
+++ b/GoRogue.PerformanceTests/Messaging/SubscriberRef.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using GoRogue.Messaging;
+
+namespace GoRogue.PerformanceTests.Messaging
+{
+    internal interface ISubscriberRef
+    {
+        object Subscriber { get; }
+        Action<object> Handler { get; }
+    }
+
+    internal class SubscriberRef<TMessage> : ISubscriberRef
+    {
+        public SubscriberRef(ISubscriber<TMessage> subscriber)
+        {
+            Subscriber = subscriber;
+            Handler = o => subscriber.Handle((TMessage)o);
+        }
+
+        public object Subscriber { get; }
+        public Action<object> Handler { get; }
+    }
+}

--- a/GoRogue/Components/ParentAware/ParentAwareComponentBase.cs
+++ b/GoRogue/Components/ParentAware/ParentAwareComponentBase.cs
@@ -5,6 +5,28 @@ using JetBrains.Annotations;
 namespace GoRogue.Components.ParentAware
 {
     /// <summary>
+    ///  EventArguments used for the <see cref="ParentAwareComponentBase.Removed"/> event.
+    /// </summary>
+    /// <typeparam name="T">The type of the parent being passed.</typeparam>
+    [PublicAPI]
+    public class ParentAwareComponentRemovedEventArgs<T> : EventArgs
+    {
+        /// <summary>
+        /// The parent from which the object was detached.
+        /// </summary>
+        public readonly T OldParent;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="oldParent">The parent from which the object was detached.</param>
+        public ParentAwareComponentRemovedEventArgs(T oldParent)
+        {
+            OldParent = oldParent;
+        }
+    }
+
+    /// <summary>
     /// Simple (and optional) base class for components attached to a class implementing
     /// <see cref="IObjectWithComponents"/>.  Adds useful events and some helper functions to allow performing
     /// type-checking of parent, or requiring that the object it's attached to has or does not have certain types of
@@ -21,7 +43,7 @@ namespace GoRogue.Components.ParentAware
         /// <summary>
         /// Fires when the component is unattached from an object
         /// </summary>
-        public event EventHandler? Removed;
+        public event EventHandler<ParentAwareComponentRemovedEventArgs<IObjectWithComponents>>? Removed;
 
         private IObjectWithComponents? _parent;
         /// <summary>
@@ -36,8 +58,10 @@ namespace GoRogue.Components.ParentAware
 
                 if (value == null)
                 {
+                    var oldValue = _parent;
                     _parent = value;
-                    Removed?.Invoke(this, EventArgs.Empty);
+                    // Null for oldValue is not possible because value == null AND value != _parent
+                    Removed?.Invoke(this, new ParentAwareComponentRemovedEventArgs<IObjectWithComponents>(oldValue!));
                 }
                 else
                 {
@@ -109,8 +133,20 @@ namespace GoRogue.Components.ParentAware
         }
 
         /// <summary>
+        /// Fires when the component is unattached from an object
+        /// </summary>
+        public new event EventHandler<ParentAwareComponentRemovedEventArgs<TParent>>? Removed;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
-        public ParentAwareComponentBase() => Added += ParentTypeCheck<TParent>;
+        public ParentAwareComponentBase()
+        {
+            Added += ParentTypeCheck<TParent>;
+            base.Removed += OnRemoved;
+        }
+
+        private void OnRemoved(object? sender, ParentAwareComponentRemovedEventArgs<IObjectWithComponents> e)
+            => Removed?.Invoke(sender, new ParentAwareComponentRemovedEventArgs<TParent>((TParent)e.OldParent));
     }
 }

--- a/GoRogue/Components/ParentAware/ParentAwareComponentBase.cs
+++ b/GoRogue/Components/ParentAware/ParentAwareComponentBase.cs
@@ -10,6 +10,7 @@ namespace GoRogue.Components.ParentAware
     /// <typeparam name="T">The type of the parent being passed.</typeparam>
     [PublicAPI]
     public class ParentAwareComponentRemovedEventArgs<T> : EventArgs
+        where T : IObjectWithComponents
     {
         /// <summary>
         /// The parent from which the object was detached.

--- a/GoRogue/GameFramework/GameObject.cs
+++ b/GoRogue/GameFramework/GameObject.cs
@@ -55,10 +55,47 @@ namespace GoRogue.GameFramework
         /// </param>
         public GameObject(Point position, int layer, bool isWalkable = true, bool isTransparent = true,
                           Func<uint>? idGenerator = null, IComponentCollection? customComponentCollection = null)
+            : this(layer, isWalkable, isTransparent, idGenerator, customComponentCollection)
+        {
+            Position = position;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="idGenerator" /> is used to generate an ID which is assigned to the <see cref="ID"/>
+        /// field. When null is specified, the constructor simply assigns a random number in range of valid uints. This
+        /// is sufficiently distinct for the purposes of placing the objects in an <see cref="ISpatialMap{T}" />
+        /// implementation, however obviously does NOT guarantee true uniqueness. If uniqueness or some other
+        /// implementation is required, override this function to return an appropriate ID. Keep in mind a relatively
+        /// high degree of uniqueness is necessary for efficient placement in an ISpatialMap implementation.
+        /// </remarks>
+        /// <param name="layer">The layer of of a <see cref="Map" /> the object is assigned to.</param>
+        /// <param name="isWalkable">
+        /// Whether or not the object is to be considered "walkable", eg. whether or not the square it resides
+        /// on can be traversed by other, non-walkable objects on the same <see cref="Map" />.  Effectively, whether or
+        /// not this object collides.
+        /// </param>
+        /// <param name="isTransparent">
+        /// Whether or not the object is considered "transparent", eg. whether or not light passes through it
+        /// for the sake of calculating the FOV of a <see cref="Map" />.
+        /// </param>
+        /// <param name="idGenerator">
+        /// The function used to generate and return an unsigned integer to use assign to the <see cref="ID" /> field.
+        /// Most of the time, you will not need to specify this as the default implementation will be sufficient.  See
+        /// the constructor remarks for details.
+        /// </param>
+        /// <param name="customComponentCollection">
+        /// A custom component collection to use for objects.  If not specified, a <see cref="ComponentCollection"/> is
+        /// used.  Typically you will not need to specify this, as a ComponentCollection is sufficient for nearly all
+        /// use cases.
+        /// </param>
+        public GameObject(int layer, bool isWalkable = true, bool isTransparent = true,
+                          Func<uint>? idGenerator = null, IComponentCollection? customComponentCollection = null)
         {
             idGenerator ??= GlobalRandom.DefaultRNG.NextUInt;
 
-            _position = position;
             Layer = layer;
             IsWalkable = isWalkable;
             IsTransparent = isTransparent;

--- a/GoRogue/GoRogue.csproj
+++ b/GoRogue/GoRogue.csproj
@@ -16,7 +16,7 @@
 
 	<!-- More nuget package settings-->
     <PackageId>GoRogue</PackageId>
-	<PackageReleaseNotes>BREAKING CHANGES from v2!  See upgrade guide at http://www.roguelib.com/articles/2-to-3-upgrade-guide.html.  Changelog at https://github.com/Chris3606/GoRogue/blob/develop-3.0/changelog.md#300-alpha06---2021-10-02.</PackageReleaseNotes>
+	<PackageReleaseNotes>BREAKING CHANGES from v2!  See upgrade guide at http://www.roguelib.com/articles/2-to-3-upgrade-guide.html.  Changelog at https://github.com/Chris3606/GoRogue/blob/develop-3.0/changelog.md#300-alpha07---2021-10-13.</PackageReleaseNotes>
 	<PackageProjectUrl>http://www.roguelib.com</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/Chris3606/GoRogue/tree/develop-3.0</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>

--- a/GoRogue/GoRogue.csproj
+++ b/GoRogue/GoRogue.csproj
@@ -11,7 +11,7 @@
     Configure versioning information, making sure to append "debug" to Debug version to allow publishing
     to NuGet seperately from Release version.
     -->
-    <Version>3.0.0-alpha06</Version>
+    <Version>3.0.0-alpha07</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 
 	<!-- More nuget package settings-->

--- a/GoRogue/Messaging/MessageBus.cs
+++ b/GoRogue/Messaging/MessageBus.cs
@@ -108,10 +108,10 @@ namespace GoRogue.Messaging
         public void Send<TMessage>(TMessage message) where TMessage : notnull
         {
             var runtimeMessageType = message.GetType();
-            if (!_typeTreeCache.ContainsKey(runtimeMessageType))
-                _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
+            if (!_typeTreeCache.TryGetValue(runtimeMessageType, out Type[]? types))
+                types = _typeTreeCache[runtimeMessageType] = ReflectionAddons.GetTypeTree(runtimeMessageType).ToArray();
 
-            foreach (var type in _typeTreeCache[runtimeMessageType])
+            foreach (var type in types)
                 if (_subscriberRefs.TryGetValue(type, out List<ISubscriberRef>? handlerRefs))
                     foreach (var handlerRef in handlerRefs)
                         handlerRef.Handler(message);

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- GameObject now has constructors that omit the parameter for starting position
+
 ### Changed
 - MessageBus now has improved performance
 - MessageBus also now supports subscribers being registered while a Send is in progress

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - MessageBus now has improved performance
 - MessageBus also now supports subscribers being registered while a Send is in progress
     - No subscribers added will be called by the in-progress Send call, however any subsequent Send calls (including nested ones) will see the new subscribers
-
+- ParentAwareComponentBase now specifies old parent in `Removed` event.
 
 ## [3.0.0-alpha06] - 2021-10-02
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-None.
+### Changed
+- MessageBus now has improved performance
+- MessageBus also now supports subscribers being registered while a Send is in progress
+    - No subscribers added will be called by the in-progress Send call, however any subsequent Send calls (including nested ones) will see the new subscribers
+
 
 ## [3.0.0-alpha06] - 2021-10-02
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,14 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+None.
+
+## [3.0.0-alpha07] - 2021-10-13
+
 ### Added
 - GameObject now has constructors that omit the parameter for starting position
 
 ### Changed
-- MessageBus now has improved performance
-- MessageBus also now supports subscribers being registered while a Send is in progress
-    - No subscribers added will be called by the in-progress Send call, however any subsequent Send calls (including nested ones) will see the new subscribers
-- ParentAwareComponentBase now specifies old parent in `Removed` event.
+- `MessageBus` now has improved performance
+- `MessageBus` also now supports subscribers being registered while a `Send` is in progress
+    - No subscribers added will be called by the in-progress `Send` call, however any subsequent `Send` calls (including nested ones) will see the new subscribers
+- `ParentAwareComponentBase` now specifies old parent in `Removed` event.
 
 ## [3.0.0-alpha06] - 2021-10-02
 


### PR DESCRIPTION
- Applies performance optimizations to `MessageBus`
- `MessageBus` now supports subscribers being registered during a `Send` call (fixes #245 )
- Adds a parameter to the `ParentAwareComponentBase.Removed` event that specifies the parent from which it was removed.
- Adds constructors for `GameObject` which omit the position parameter and instead default it to (0, 0)