### PR TITLE
Fix bug in GoalMapExtensions.GetDirectionOfMinValue for open edged maps

### DIFF
--- a/GoRogue.UnitTests/Pathing/GoalMapTests.cs
+++ b/GoRogue.UnitTests/Pathing/GoalMapTests.cs
@@ -53,5 +53,26 @@ namespace GoRogue.UnitTests.Pathing
 
             // TODO: Verify goal map leads to goal
         }
+
+        [Fact]
+        public void GetDirectionOfMinValueChecksMapBoundaryForOpenEdgedMaps()
+        {
+            var map = MockMaps.Rectangle(2, 1);
+
+            var goalMapData = new ArrayView<GoalState>(map.Width, map.Height);
+            goalMapData.Fill(GoalState.Clear);
+
+            var goalPos = new Point(1, 0);
+
+            goalMapData[goalPos] = GoalState.Goal;
+
+            var goalMap = new GoalMap(goalMapData, Distance.Chebyshev);
+            goalMap.Update();
+
+            var startPos = new Point(0, 0);
+            var dir = goalMap.GetDirectionOfMinValue(startPos);
+
+            Assert.Equal(goalPos, startPos + dir);
+        }
     }
 }

--- a/GoRogue/Pathing/GoalMapExtensions.cs
+++ b/GoRogue/Pathing/GoalMapExtensions.cs
@@ -29,7 +29,8 @@ namespace GoRogue.Pathing
             foreach (var dir in adjacencyRule.DirectionsOfNeighbors())
             {
                 var newPosition = position + dir;
-                if (!goalMap[newPosition].HasValue)
+
+                if (!goalMap.Contains(newPosition) || !goalMap[newPosition].HasValue)
                     continue;
 
                 if (goalMap[newPosition]!.Value <= min

--- a/GoRogue/Pathing/WeightedGoalMap.cs
+++ b/GoRogue/Pathing/WeightedGoalMap.cs
@@ -122,9 +122,9 @@ namespace GoRogue.Pathing
                     var weight = pair.Value;
                     var weighted = value.Value * weight;
                     if (weight > 0.0)
-                        result = Math.Abs(result) < 0.0000000001 ? weighted : result * weighted;
+                        result = Math.Abs(result) < 0.0000000001 ? weighted : result + weighted;
                     else
-                        negResult = Math.Abs(negResult) < 0.0000000001 ? weighted : negResult * weighted;
+                        negResult = Math.Abs(negResult) < 0.0000000001 ? weighted : negResult + weighted;
                 }
 
                 return result + negResult;


### PR DESCRIPTION
Fix bug in GoalMapExtensions.GetDirectionOfMinValue where the foreach loop over each direction does not check that the new position falls within the goal map's boundary.