### PR TITLE
making the value change when the value is different from before

### DIFF
--- a/GoRogue/GameFramework/Map.cs
+++ b/GoRogue/GameFramework/Map.cs
@@ -277,7 +277,6 @@ namespace GoRogue.GameFramework
 
             if (useCachedGridViews)
             {
-
                 _cachedTransparencyView = new BitArrayView(_terrain.Width, _terrain.Height);
                 TransparencyView = _cachedTransparencyView;
                 _cachedWalkabilityView = new BitArrayView(_terrain.Width, _terrain.Height);

--- a/GoRogue/GameFramework/Map.cs
+++ b/GoRogue/GameFramework/Map.cs
@@ -277,7 +277,7 @@ namespace GoRogue.GameFramework
 
             if (useCachedGridViews)
             {
-                
+
                 _cachedTransparencyView = new BitArrayView(_terrain.Width, _terrain.Height);
                 TransparencyView = _cachedTransparencyView;
                 _cachedWalkabilityView = new BitArrayView(_terrain.Width, _terrain.Height);
@@ -363,7 +363,7 @@ namespace GoRogue.GameFramework
         private void Item_TransparencyChangedSyncView(object? sender, ValueChangedEventArgs<bool> e)
         {
             var obj = (IGameObject)sender!;
-            if (e.NewValue)
+            if (e.NewValue != e.OldValue)
                 _cachedTransparencyView![obj.Position] = LayersBlockingTransparency == 1
                     ? _terrain[obj.Position]?.IsTransparent ?? true
                     : FullIsTransparent(obj.Position);


### PR DESCRIPTION
Updated the Item_TransparencyChangedSyncView method to only update _cachedTransparencyView when the new value differs from the old one.
This fixes the issue when the NewValue only updated the _cachedTransparencyView when it was set to true.