### PR TITLE
Support dX dice shorthand

### DIFF
--- a/GoRogue.UnitTests/DiceNotation/DiceNotationTests.cs
+++ b/GoRogue.UnitTests/DiceNotation/DiceNotationTests.cs
@@ -52,6 +52,10 @@ namespace GoRogue.UnitTests.DiceNotation
             ("d6", 1, 6),
             // Single die shorthand with multiply and add
             ("d12*2+3", 5, 27),
+            // Parenthesized expression as dice count
+            ("(3+2)d10", 5, 50),
+            // Whitespace before dice operator
+            ("2 d6", 2, 12),
             // Single dice with add
             ("1d6+3", 4, 9),
             // Single dice with add and multiply

--- a/GoRogue.UnitTests/DiceNotation/DiceNotationTests.cs
+++ b/GoRogue.UnitTests/DiceNotation/DiceNotationTests.cs
@@ -48,6 +48,10 @@ namespace GoRogue.UnitTests.DiceNotation
             ("3*2d6", 6, 36),
             // Single dice
             ("1d6", 1, 6),
+            // Single die shorthand
+            ("d6", 1, 6),
+            // Single die shorthand with multiply and add
+            ("d12*2+3", 5, 27),
             // Single dice with add
             ("1d6+3", 4, 9),
             // Single dice with add and multiply

--- a/GoRogue/DiceNotation/Parser.cs
+++ b/GoRogue/DiceNotation/Parser.cs
@@ -133,6 +133,9 @@ namespace GoRogue.DiceNotation
                 }
                 else // Separate so we can increment charIndex differently
                 {
+                    if (infix[charIndex] == 'd' && lastWasOperator)
+                        output.Add("1");
+
                     lastWasOperator = true;
                     switch (infix[charIndex])
                     {

--- a/GoRogue/DiceNotation/Parser.cs
+++ b/GoRogue/DiceNotation/Parser.cs
@@ -133,13 +133,10 @@ namespace GoRogue.DiceNotation
                 }
                 else // Separate so we can increment charIndex differently
                 {
-                    if (infix[charIndex] == 'd' && lastWasOperator)
-                        output.Add("1");
-
-                    lastWasOperator = true;
                     switch (infix[charIndex])
                     {
                         case '(':
+                            lastWasOperator = true;
                             operators.Push(infix[charIndex]);
                             break;
                         case ')':
@@ -151,17 +148,22 @@ namespace GoRogue.DiceNotation
                                 op = operators.Pop();
                             }
 
+                            lastWasOperator = false;
                             break;
                         }
                         default:
                         {
                             if (s_operatorPrecedence.ContainsKey(infix[charIndex]))
                             {
+                                if (infix[charIndex] == 'd' && lastWasOperator)
+                                    output.Add("1");
+
                                 while (operators.Count > 0 && s_operatorPrecedence[operators.Peek()] >=
                                     s_operatorPrecedence[infix[charIndex]])
                                     output.Add(operators.Pop().ToString());
 
                                 operators.Push(infix[charIndex]);
+                                lastWasOperator = true;
                             }
 
                             break;


### PR DESCRIPTION
## Summary

- Accept dice shorthand such as `dX` by treating a leading `d` as an implicit single-die operand.
- Preserve parser operand state so shorthand works correctly around closing parentheses and whitespace.
- Add regression coverage for shorthand and the related parser transitions.

## Validation

- Focused tests: 19/19.
- Neighboring parser tests: 22/22.
- Complete `GoRogue.UnitTests`: 1326/1326 in Debug.
- Complete `GoRogue.UnitTests`: 1326/1326 in Release.

Fixes #337
